### PR TITLE
Moved to functional localstorage interface

### DIFF
--- a/store.coffee
+++ b/store.coffee
@@ -1,6 +1,6 @@
 module.exports = (query, cb) ->
   result = {}
   for key, value of query
-    result[key] = JSON.parse localStorage[value.__params]
+    result[key] = JSON.parse localStorage.getItem(value.__params)
   cb null, result
   -> clearTimeout handle

--- a/store.js
+++ b/store.js
@@ -4,7 +4,7 @@ module.exports = function(query, cb) {
   result = {};
   for (key in query) {
     value = query[key];
-    result[key] = JSON.parse(localStorage[value.__params]);
+    result[key] = JSON.parse(localStorage.getItem(value.__params));
   }
   cb(null, result);
   return function() {


### PR DESCRIPTION
Functional interface returns null for nonexistent keys, instead of
undefined, which creates JSON errors. Fixes issue #1.
